### PR TITLE
Added a Cargo crate with several paper bins

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -3248,6 +3248,18 @@
 					/obj/item/laser_pointer/purple)
 	crate_name = "bureaucracy crate"
 
+/datum/supply_pack/misc/bulk_paper
+	name = "Bulk Paper Tray Crate"
+	dec = "Plenty of paper for all your papercraft needs."
+	cost = 500
+	max_supply = 5
+	contains = list(/obj/item/paper_bin,
+					/obj/item/paper_bin,
+					/obj/item/paper_bin,
+					/obj/item/paper_bin,
+					/obj/item/paper_bin)
+	crate_name = "bulk paper tray crate"
+
 /datum/supply_pack/misc/fountainpens
 	name = "Calligraphy Crate"
 	desc = "Sign death warrants in style with these seven executive fountain pens."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new Crate to cargo that gives five paper trays.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Paper has many uses from taking notes, to origami, to crafting paper ID and printing off paintings in the library, however after raiding all of the offices around the station there is no way to get more outside of buying the woefully inefficient bureaucracy crate that only has one paper tray for 800 credits, this new tray will make is possible for the station to get more paper and encourage players to find creative uses for this versatile resource.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![paper1](https://github.com/theoctopusempress/BeeStation-Hornet/assets/78881224/dbce972e-8d79-419e-9f43-5f2f748b7f55)

![paper2](https://github.com/theoctopusempress/BeeStation-Hornet/assets/78881224/32edbfca-7bb0-4718-8429-71856d083164)


</details>

## Changelog
:cl:
add: Cargo crate containing five paper trays for 500 credits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
